### PR TITLE
fix(andesite): disable growpart

### DIFF
--- a/machines/andesite/configuration.nix
+++ b/machines/andesite/configuration.nix
@@ -1,4 +1,9 @@
-{ inputs, pkgs, ... }:
+{
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
 {
   imports = [
     inputs.self.nixosModules.from-facts
@@ -24,6 +29,7 @@
 
   # this gets enabled by srvos
   services.cloud-init.enable = false;
+  boot.growPartition = lib.mkForce false;
 
   services.openssh.enable = true;
 


### PR DESCRIPTION
It assumes that / is the device that needs to be grown, but we use /nix
and impermanence.

Signed-off-by: Sefa Eyeoglu <contact@scrumplex.net>
